### PR TITLE
Adding additional operating systems in testing

### DIFF
--- a/.github/workflows/capgen_unit_tests.yaml
+++ b/.github/workflows/capgen_unit_tests.yaml
@@ -12,14 +12,14 @@ jobs:
         os: [ubuntu-22.04, ubuntu-24.04]
         fortran-compiler: [gfortran-9, gfortran-10, gfortran-11, gfortran-12, gfortran-13, gfortran-14]
         exclude:
-          os: ubuntu-24.04
-          fortran-compiler: gfortran-9
-          os: ubuntu-24.04
-          fortran-compiler: gfortran-10
-          os: ubuntu-24.04
-          fortran-compiler: gfortran-11
-          os: ubuntu-22.04
-          fortran-compiler: gfortran-14
+          - os: ubuntu-24.04
+            fortran-compiler: gfortran-9
+          - os: ubuntu-24.04
+            fortran-compiler: gfortran-10
+          - os: ubuntu-24.04
+            fortran-compiler: gfortran-11
+          - os: ubuntu-22.04
+            fortran-compiler: gfortran-14
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/capgen_unit_tests.yaml
+++ b/.github/workflows/capgen_unit_tests.yaml
@@ -9,8 +9,8 @@ jobs:
   unit_tests:
     strategy:
       matrix:
-        os: [ ubuntu-22.04, ubuntu-24.04 ]
-        fortran-compiler: [ gfortran-9, gfortran-10, gfortran-11, gfortran-12, gfortran-13, gfortran-14 ]
+        os: [ubuntu-22.04, ubuntu-24.04]
+        fortran-compiler: [gfortran-9, gfortran-10, gfortran-11, gfortran-12, gfortran-13, gfortran-14]
         exclude:
           os: ubuntu-24.04
           fortran-compiler: gfortran-9

--- a/.github/workflows/capgen_unit_tests.yaml
+++ b/.github/workflows/capgen_unit_tests.yaml
@@ -7,10 +7,20 @@ on:
 
 jobs:
   unit_tests:
-    runs-on: ubuntu-latest
     strategy:
       matrix:
-        fortran-compiler: [gfortran-9, gfortran-10, gfortran-11, gfortran-12, gfortran-13]
+        os: [ ubuntu-22.04, ubuntu-24.04 ]
+        fortran-compiler: [ gfortran-9, gfortran-10, gfortran-11, gfortran-12, gfortran-13, gfortran-14 ]
+        exclude:
+          os: ubuntu-24.04
+          fortran-compiler: gfortran-9
+          os: ubuntu-24.04
+          fortran-compiler: gfortran-10
+          os: ubuntu-24.04
+          fortran-compiler: gfortran-11
+          os: ubuntu-22.04
+          fortran-compiler: gfortran-14
+    runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3
     - name: update repos and install dependencies


### PR DESCRIPTION
Adding additional matrix param for both os's and excluding invalid combinations.

Adds additional matrix param for ubuntu-24.04 and excludes invalid combinations of OS's and compilers.

User interface changes?: No

Fixes: [Github issue #s] N\A

Testing:
  test removed: None
  unit tests: all
  system tests: N\A
  manual testing: N\A