### PR TITLE
Fix issue with not finding indexed fields

### DIFF
--- a/scripts/metavar.py
+++ b/scripts/metavar.py
@@ -674,13 +674,16 @@ class Var:
         # end if
         return dimstr
 
-    def call_string(self, var_dict, loop_vars=None):
+    def call_string(self, var_dicts, loop_vars=None):
         """Construct the actual argument string for this Var by translating
         standard names to local names.
         String includes array bounds unless loop_vars is None.
         if <loop_vars> is not None, look there first for array bounds,
         even if usage requires a loop substitution.
         """
+        if not isinstance(var_dicts, list):
+           var_dicts = [var_dicts]
+        # end if
         if loop_vars is None:
             call_str = self.get_prop_value('local_name')
             # Look for dims in case this is an array selection variable
@@ -709,8 +712,15 @@ class Var:
                     lname = ""
                     for item in dim.split(':'):
                         if item:
-                            dvar = var_dict.find_variable(standard_name=item,
-                                                          any_scope=False)
+                            for var_dict in var_dicts:
+                                dvar = var_dict.find_variable(standard_name=item,
+                                                              any_scope=False)
+                                if dvar is not None:
+                                    iname = dvar.call_string(var_dict,
+                                                             loop_vars=loop_vars)
+                                    break
+                                # end if
+                            # end for
                             if dvar is None:
                                 try:
                                     dval = int(item)
@@ -718,9 +728,6 @@ class Var:
                                 except ValueError:
                                     iname = None
                                 # end try
-                            else:
-                                iname = dvar.call_string(var_dict,
-                                                         loop_vars=loop_vars)
                             # end if
                         else:
                             iname = ''
@@ -729,9 +736,8 @@ class Var:
                             lname = lname + isep + iname
                             isep = ':'
                         else:
-                            errmsg = 'No local variable {} in {}{}'
+                            errmsg = 'No local variable {} in variable dictionaries'
                             ctx = context_string(self.context)
-                            dname = var_dict.name
                             raise CCPPError(errmsg.format(item, dname, ctx))
                         # end if
                     # end for

--- a/scripts/suite_objects.py
+++ b/scripts/suite_objects.py
@@ -159,7 +159,7 @@ class CallList(VarDictionary):
                         raise CCPPError(errmsg.format(stdname, clnames))
                     # end if
                     dimensions = dvar.get_dimensions()
-                    lname = dvar.call_string(cldict)
+                    lname = dvar.call_string(cldicts)
                     # Optional variables in the caps are associated with
                     # local pointers of <lname>_ptr
                     if var.get_prop_value('optional'):
@@ -770,7 +770,7 @@ class SuiteObject(VarDictionary):
             if self.phase() == 'register':
                 found_var = True
                 new_vdims = [':']
-                return found_var, local_var, dict_var, var_vdim, new_vdims, compat_obj
+                return found_var, local_var, dict_var, var_vdim, new_vdims, compat_obj, scheme_var
             else:
                 errmsg = "Variables of type ccpp_constituent_properties_t only allowed in register phase: "
                 sname  = var.get_prop_value('standard_name')

--- a/test/README.md
+++ b/test/README.md
@@ -49,6 +49,7 @@ There are several `<options>...` to enable tests:
 3) `-DCCPP_RUN_CAPGEN_TEST=ON` Turns on only the capgen test
 4) `-DCCPP_RUN_DDT_HOST_TEST=ON` Turns on only the ddt host test
 5) `-DCCPP_RUN_VAR_COMPATIBILITY_TEST=ON` Turns on only the variable compatibility test
+5) `-DCCPP_RUN_NESTED_SUITE_TEST=ON` Turns on only the nested suite test
 
 By default, the tests will build in release mode.  To enable debug mode, you will need to set the build type: `-DCMAKE_BUILD_TYPE=Release` (or if you want release with debug symbols: `-DCMAKE_BUILD_TYPE=RelWithDebInfo`).
 


### PR DESCRIPTION
Conditionally search a list of dictionaries in call_string to find necessary dimensions or indices in other accessible dictionaries.
