### PR TITLE
add more testing to advection test

### DIFF
--- a/scripts/host_model.py
+++ b/scripts/host_model.py
@@ -192,10 +192,16 @@ class HostModel(VarDictionary):
         # Now, find all the used module variables
         cap_modname = self.ccpp_cap_name()
         for name in lnames:
+            # Grab base local name; no dimensions
+            if '(' in name:
+                newname = name.split('(')[0]
+            else:
+                newname = name
+            # End if
             module = self.host_variable_module(name)
             used = self.__used_variables and (name in self.__used_variables)
             if module and used and (module != cap_modname):
-                varset.add((module, name))
+                varset.add((module, newname))
             # No else, either no module or a zero-length module name
             # End if
         # End for

--- a/scripts/metavar.py
+++ b/scripts/metavar.py
@@ -891,8 +891,8 @@ class Var:
     @parent.setter
     def parent(self, parent_var):
         """Set this variable's parent if not already set"""
-        if self.__parent_var is not None:
-            emsg = 'Attempting to set parent for {} but parent already set'
+        if self.__parent_var is not None and self.__parent_var != parent_var:
+            emsg = 'Attempting to set parent for {} but different parent already set'
             lname = self.get_prop_value('local_name')
             raise ParseInternalError(emsg.format(lname))
         # end if

--- a/test/advection_test/cld_ice.F90
+++ b/test/advection_test/cld_ice.F90
@@ -48,13 +48,14 @@ contains
   !> \section arg_table_cld_ice_run  Argument Table
   !! \htmlinclude arg_table_cld_ice_run.html
   !!
-  subroutine cld_ice_run(ncol, timestep, temp, qv, ps, cld_ice_array, &
+  subroutine cld_ice_run(ncol, timestep, temp, qv, qv_not_state, ps, cld_ice_array, &
       errmsg, errflg)
 
     integer, intent(in) :: ncol
     real(kind=kind_phys), intent(in) :: timestep
     real(kind=kind_phys), intent(inout) :: temp(:, :)
     real(kind=kind_phys), intent(inout) :: qv(:, :)
+    real(kind=kind_phys), intent(inout) :: qv_not_state(:, :)
     real(kind=kind_phys), intent(in) :: ps(:)
     real(kind=kind_phys), intent(inout) :: cld_ice_array(:, :)
     character(len=512), intent(out) :: errmsg
@@ -75,6 +76,7 @@ contains
           frz = max(qv(icol, ilev) - 0.5_kind_phys, 0.0_kind_phys)
           cld_ice_array(icol, ilev) = cld_ice_array(icol, ilev) + frz
           qv(icol, ilev) = qv(icol, ilev) - frz
+          qv_not_state(icol, ilev) = qv_not_state(icol, ilev) - frz
           if (frz > 0.0_kind_phys) then
             temp(icol, ilev) = temp(icol, ilev) + 1.0_kind_phys
           end if

--- a/test/advection_test/cld_ice.meta
+++ b/test/advection_test/cld_ice.meta
@@ -58,6 +58,13 @@
   type = real
   kind = kind_phys
   intent = inout
+[ qv_not_state ]
+  standard_name = water_vapor_specific_humidity_not_state
+  units = kg kg-1
+  dimensions = (horizontal_loop_extent, vertical_layer_dimension)
+  type = real
+  kind = kind_phys
+  intent = inout
 [ ps ]
   standard_name = surface_air_pressure
   state_variable = true

--- a/test/advection_test/cld_liq.F90
+++ b/test/advection_test/cld_liq.F90
@@ -41,7 +41,7 @@ contains
   !> \section arg_table_cld_liq_run  Argument Table
   !! \htmlinclude arg_table_cld_liq_run.html
   !!
-  subroutine cld_liq_run(ncol, timestep, tcld, temp, qv, ps, &
+  subroutine cld_liq_run(ncol, timestep, tcld, temp, qv, qv_not_state, ps, &
       cld_liq_tend, errmsg, errflg)
 
     integer, intent(in) :: ncol
@@ -49,6 +49,7 @@ contains
     real(kind=kind_phys), intent(in) :: tcld
     real(kind=kind_phys), intent(inout) :: temp(:, :)
     real(kind=kind_phys), intent(inout) :: qv(:, :)
+    real(kind=kind_phys), intent(inout) :: qv_not_state(:, :)
     real(kind=kind_phys), intent(in) :: ps(:)
     real(kind=kind_phys), intent(inout) :: cld_liq_tend(:, :)
     character(len=512), intent(out) :: errmsg
@@ -70,6 +71,7 @@ contains
           cond = min(qv(icol, ilev), 0.1_kind_phys)
           cld_liq_tend(icol, ilev) = cond
           qv(icol, ilev) = qv(icol, ilev) - cond
+          qv_not_state(icol, ilev) = qv_not_state(icol, ilev) - cond
           if (cond > 0.0_kind_phys) then
             temp(icol, ilev) = temp(icol, ilev) + (cond * 5.0_kind_phys)
           end if

--- a/test/advection_test/cld_liq.meta
+++ b/test/advection_test/cld_liq.meta
@@ -63,6 +63,13 @@
   type = real
   kind = kind_phys
   intent = inout
+[ qv_not_state ]
+  standard_name = water_vapor_specific_humidity_not_state
+  units = kg kg-1
+  dimensions = (horizontal_loop_extent, vertical_layer_dimension)
+  type = real
+  kind = kind_phys
+  intent = inout
 [ ps ]
   standard_name = surface_air_pressure
   state_variable = true

--- a/test/advection_test/test_advection_host_integration.F90
+++ b/test/advection_test/test_advection_host_integration.F90
@@ -7,9 +7,9 @@ program test
   implicit none
 
   character(len=cs), target :: test_parts1(1)
-  character(len=cm), target :: test_invars1(8)
-  character(len=cm), target :: test_outvars1(11)
-  character(len=cm), target :: test_reqvars1(14)
+  character(len=cm), target :: test_invars1(9)
+  character(len=cm), target :: test_outvars1(12)
+  character(len=cm), target :: test_reqvars1(15)
 
   type(suite_info) :: test_suites(1)
   logical :: run_okay
@@ -24,9 +24,11 @@ program test
       'tendency_of_cloud_liquid_dry_mixing_ratio', &
       'banana_array_dim                         ', &
       'time_step_for_physics                    ', &
+      'water_vapor_specific_humidity_not_state  ', &
       'water_temperature_at_freezing            ' /)
   test_outvars1 = (/ &
       'ccpp_model_constituents_object           ', &
+      'water_vapor_specific_humidity_not_state  ', &
       'cloud_ice_dry_mixing_ratio               ', &
       'cloud_liquid_dry_mixing_ratio            ', &
       'physics_state_derived_type               ', &
@@ -43,6 +45,7 @@ program test
       'cloud_liquid_dry_mixing_ratio            ', &
       'physics_state_derived_type               ', &
       'tendency_of_cloud_liquid_dry_mixing_ratio', &
+      'water_vapor_specific_humidity_not_state  ', &
       'banana_array_dim                         ', &
       'time_step_for_physics                    ', &
       'water_temperature_at_freezing            ', &

--- a/test/advection_test/test_host.F90
+++ b/test/advection_test/test_host.F90
@@ -78,7 +78,8 @@ contains
     end if
     ! Check the input variables
     call ccpp_physics_suite_variables(test_suite%suite_name, test_list, &
-        errmsg, errflg, input_vars=.true., output_vars=.false.)
+        errmsg, errflg, input_vars=.true., output_vars=.false., &
+        struct_elements=.false.)
     if (errflg == 0) then
       check = check_list(test_list, test_suite%suite_input_vars, &
           'input variable names', suite_name=test_suite%suite_name)
@@ -92,7 +93,8 @@ contains
     end if
     ! Check the output variables
     call ccpp_physics_suite_variables(test_suite%suite_name, test_list, &
-        errmsg, errflg, input_vars=.false., output_vars=.true.)
+        errmsg, errflg, input_vars=.false., output_vars=.true., &
+        struct_elements=.false.)
     if (errflg == 0) then
       check = check_list(test_list, test_suite%suite_output_vars, &
           'output variable names', suite_name=test_suite%suite_name)
@@ -106,7 +108,7 @@ contains
     end if
     ! Check all required variables
     call ccpp_physics_suite_variables(test_suite%suite_name, test_list, &
-        errmsg, errflg)
+        errmsg, errflg, struct_elements=.false.)
     if (errflg == 0) then
       check = check_list(test_list, test_suite%suite_required_vars, &
           'required variable names', suite_name=test_suite%suite_name)
@@ -122,7 +124,7 @@ contains
 
   subroutine advect_constituents()
     use test_host_mod, only: phys_state, &
-        ncnst
+        ncnst, q_not_state
     use test_host_mod, only: twist_array
 
     ! Local variables
@@ -130,6 +132,7 @@ contains
 
     do q_ind = 1, ncnst ! Skip checks, they were done in constituents_in
       call twist_array(phys_state%q(:, :, q_ind))
+      call twist_array(q_not_state(:, :, q_ind))
     end do
   end subroutine advect_constituents
 

--- a/test/advection_test/test_host_mod.F90
+++ b/test/advection_test/test_host_mod.F90
@@ -18,11 +18,13 @@ module test_host_mod
   integer, parameter :: pverp = pver + 1
   integer, protected :: ncnst = -1
   integer, protected :: index_qv = -1
+  integer, protected :: index_qv_not_state = -1
   real(kind=kind_phys) :: dt
   real(kind=kind_phys), parameter :: tfreeze = 273.15_kind_phys
   type(physics_state) :: phys_state
   integer :: num_model_times = -1
   integer, allocatable :: model_times(:)
+  real(kind=kind_phys), allocatable :: q_not_state(:,:,:)
 
   public :: init_data
   public :: compare_data
@@ -58,9 +60,12 @@ contains
     ncnst = size(constituent_array, 3)
     call allocate_physics_state(ncols, pver, constituent_array, phys_state)
     index_qv = index_qv_use
+    index_qv_not_state = index_qv_use
     ind_liq = index_liq
     ind_ice = index_ice
     allocate(check_vals(ncols, pver, ncnst))
+    allocate(q_not_state(ncols, pver, ncnst))
+    q_not_state = constituent_array
     check_vals(:, :, :) = 0.0_kind_phys
     check_vals(:, :, index_dyn) = 1.0_kind_phys
     do lev = 1, pver
@@ -69,8 +74,10 @@ contains
       do col = 1, ncols
         if (mod(col, 2) == 1) then
           phys_state%q(col, lev, index_qv) = qmax
+          q_not_state(col, lev, index_qv_not_state) = qmax
         else
           phys_state%q(col, lev, index_qv) = 0.0_kind_phys
+          q_not_state(col, lev, index_qv_not_state) = 0.0_kind_phys
         end if
       end do
     end do
@@ -166,6 +173,19 @@ contains
             write(6, '(3i5,2(3x,es15.7))') col, lev, cind, &
                 phys_state%q(col, lev, cind), check
             compare_data = .false.
+          end if
+          if (cind == index_qv_not_state) then
+            if (abs((q_not_state(col, lev, cind) - check) / denom) >      &
+                tolerance) then
+              if (need_header) then
+                write(6, '(2(2x,a),3x,a,10x,a,14x,a)')                   &
+                    'COL', 'LEV', 'C#', 'Q NOT STATE', 'EXPECTED'
+                need_header = .false.
+              end if
+              write(6, '(3i5,2(3x,es15.7))') col, lev, cind,              &
+                  q_not_state(col, lev, cind), check
+              compare_data = .false.
+            end if
           end if
         end do
       end do

--- a/test/advection_test/test_host_mod.meta
+++ b/test/advection_test/test_host_mod.meta
@@ -34,6 +34,12 @@
   type = integer
   protected = True
   dimensions = ()
+[ index_qv_not_state ]
+  standard_name = index_of_water_vapor_specific_humidity_not_state
+  units = index
+  type = integer
+  protected = True
+  dimensions = ()
 [ dt ]
   standard_name = time_step_for_physics
   long_name = time step
@@ -62,3 +68,15 @@
   dimensions = (number_of_model_times)
   type = integer
   allocatable = True
+[ q_not_state ]
+  standard_name = constituent_mixing_ratio_not_state
+  type = real
+  kind = kind_phys
+  units = kg kg-1 moist or dry air depending on type
+  dimensions = (horizontal_dimension, vertical_layer_dimension, number_of_tracers)
+[ q_not_state(:,:,index_of_water_vapor_specific_humidity_not_state) ]
+  standard_name = water_vapor_specific_humidity_not_state
+  type = real
+  kind = kind_phys
+  units = kg kg-1
+  dimensions = (horizontal_dimension, vertical_layer_dimension)


### PR DESCRIPTION
Handle indexed variables that are not members of a ddt.

# Summary of changes
```
M   scripts/host_model.py
- use base name in use statement (not the whole local name)

M   scripts/metavar.py
- allow parent to be set to the same variable

M   test/advection_test/*
- add new constituent array variable that is not a state variable; ensure a member of that array is passed around correctly and answers match at the end.
```

User interface changes?: No

