### PR TITLE
bug/unalloc_var_to_group Dom cleanup

### DIFF
--- a/scripts/ddt_library.py
+++ b/scripts/ddt_library.py
@@ -101,6 +101,27 @@ class VarDDT(Var):
         # end if
         return clone_var
 
+    def call_dimstring(self, var_dicts=None, explicit_dims=False,
+                       loop_subst=False, prepend_varname=False):
+        """Return the dimensions string for a variable call.
+        If <var_dict> is present, find and substitute a local_name for
+        each standard_name in this variable's dimensions.
+        If <var_dict> is not present, return a colon for each dimension.
+        If <explicit_dims> is True, include the variable's dimensions.
+        If <loop_subst> is True, apply a loop substitution, if found for any
+           missing dimension.
+        If <prepend_varname> is True, prepend the VarDDT's local name sequence.
+        """
+        if self.field is not None:
+            dimstr = self.field.call_dimstring(
+                var_dicts=var_dicts, explicit_dims=explicit_dims,
+                loop_subst=loop_subst, prepend_varname=prepend_varname)
+        # end if
+        # DH Copied from below: XXgoldyXX: Need to add dimensions to this
+        if prepend_varname:
+            dimstr = super().get_prop_value('local_name') + '%' + dimstr
+        return dimstr
+
     def call_string(self, var_dict, loop_vars=None):
         """Return a legal call string of this VarDDT's local name sequence.
         """

--- a/scripts/ddt_library.py
+++ b/scripts/ddt_library.py
@@ -103,13 +103,7 @@ class VarDDT(Var):
 
     def call_dimstring(self, var_dicts=None, explicit_dims=False,
                        loop_subst=False, prepend_varname=False):
-        """Return the dimensions string for a variable call.
-        If <var_dict> is present, find and substitute a local_name for
-        each standard_name in this variable's dimensions.
-        If <var_dict> is not present, return a colon for each dimension.
-        If <explicit_dims> is True, include the variable's dimensions.
-        If <loop_subst> is True, apply a loop substitution, if found for any
-           missing dimension.
+        """Return the dimensions string for a variable call for self.field.
         If <prepend_varname> is True, prepend the VarDDT's local name sequence.
         """
         if self.field is not None:

--- a/scripts/file_utils.py
+++ b/scripts/file_utils.py
@@ -286,7 +286,7 @@ def move_modified_files(src_dir, dest_dir, overwrite=False, remove_src=False):
                 if overwrite:
                     fmove = True
                 else:
-                    fmove = filecmp.cmp(src_path, dest_path, shallow=False)
+                    fmove = not filecmp.cmp(src_path, dest_path, shallow=False)
                 # end if
             else:
                 fmove = True

--- a/scripts/fortran_tools/parse_fortran.py
+++ b/scripts/fortran_tools/parse_fortran.py
@@ -317,6 +317,10 @@ class FtypeCharacter(Ftype):
     'Character(len=512)'
     >>> FtypeCharacter('character(*)', None).__str__()
     'character(len=*)'
+    >>> FtypeCharacter('character(nf_file_length)', None).__str__()
+    'character(len=nf_file_length)'
+    >>> FtypeCharacter('character(len=nf_file_length)', None).__str__()
+    'character(len=nf_file_length)'
     >>> FtypeCharacter('character*7', None).__str__() #doctest: +IGNORE_EXCEPTION_DETAIL
     Traceback (most recent call last):
     ParseSyntaxError: Invalid character declaration, 'character*7', at <standard input>:1
@@ -335,9 +339,9 @@ class FtypeCharacter(Ftype):
     "character(len=15, kind=kind('b'))"
     """
 
-    char_re = re.compile(r"(?i)(character)\s*(\([A-Za-z0-9,=*:\s\'\"()]+\))?")
+    char_re = re.compile(r"(?i)(character)\s*(\([A-Za-z0-9_,=*:\s\'\"()]+\))?")
     chartrail_re = re.compile(r"\s*[,:]|\s+[A-Z]")
-    oldchar_re = re.compile(r"(?i)(character)\s*(\*)\s*([0-9]+\s*)")
+    oldchar_re = re.compile(r"(?i)(character)\s*(\*)\s*([A-Za-z0-9_]+\s*)")
     oldchartrail_re = re.compile(r"\s*[,]|\s+[A-Z]")
     len_token_re = re.compile(r"(?i)([:]|[*]|[0-9]+|[A-Z][A-Z0-9_]*)$")
 

--- a/scripts/metavar.py
+++ b/scripts/metavar.py
@@ -622,6 +622,7 @@ class Var:
         If <explicit_dims> is True, include the variable's dimensions.
         If <loop_subst> is True, apply a loop substitution, if found for any
            missing dimension.
+        If <prepend_varname> is True, prepend the local variable name.
         """
         emsg = ''
         varname, dims = self.handle_array_ref()

--- a/scripts/metavar.py
+++ b/scripts/metavar.py
@@ -360,7 +360,6 @@ class Var:
         # Make sure all the variable values are valid
         try:
             for prop_name, prop_val in self.var_properties():
-                #print(f"DHDEBUG: prop_name, prop_val: '{prop_name}' / '{prop_val}'")
                 prop = Var.get_prop(prop_name)
                 _ = prop.valid_value(prop_val,
                                      prop_dict=self._prop_dict, error=True)
@@ -562,8 +561,6 @@ class Var:
         ('foo', ['ccpp_constant_one:dim1', 'ccpp_constant_one:dim2', 'bar'])
         >>> Var({'local_name' : 'foo(bar,:)', 'standard_name' : 'hi_mom', 'units' : 'm s-1', 'dimensions' : '(ccpp_constant_one:dim1)', 'type' : 'real',}, ParseSource('vname', 'HOST', ParseContext()), _MVAR_DUMMY_RUN_ENV).handle_array_ref()
         ('foo', ['bar', 'ccpp_constant_one:dim1'])
-        >>> Var({'local_name' : 'foo(:)', 'standard_name' : 'hi_mom', 'units' : 'm s-1', 'dimensions' : '(ccpp_constant_one:dim1)', 'type' : 'real',}, ParseSource('vname', 'HOST', ParseContext()), _MVAR_DUMMY_RUN_ENV).handle_array_ref()
-        ('foo', ['ccpp_constant_one:dim1'])
         >>> Var({'local_name' : 'foo(bar)', 'standard_name' : 'hi_mom', 'units' : 'm s-1', 'dimensions' : '(ccpp_constant_one:dim1)', 'type' : 'real',}, ParseSource('vname', 'HOST', ParseContext()), _MVAR_DUMMY_RUN_ENV).handle_array_ref() #doctest: +IGNORE_EXCEPTION_DETAIL
         Traceback (most recent call last):
         CCPPError: Call dims mismatch for foo(bar), not enough colons
@@ -714,8 +711,8 @@ class Var:
         even if usage requires a loop substitution.
         """
         # DH*
-        #if loop_vars:
-        #    raise Exception(f"DH DEBUG: WE DO USE loop_vars in call_string! '{loop_vars}'")
+        if loop_vars:
+            raise Exception(f"DH DEBUG: WE DO USE loop_vars in call_string! '{loop_vars}'")
         # *DH
         if not isinstance(var_dicts, list):
            var_dicts = [var_dicts]

--- a/scripts/metavar.py
+++ b/scripts/metavar.py
@@ -360,6 +360,7 @@ class Var:
         # Make sure all the variable values are valid
         try:
             for prop_name, prop_val in self.var_properties():
+                #print(f"DHDEBUG: prop_name, prop_val: '{prop_name}' / '{prop_val}'")
                 prop = Var.get_prop(prop_name)
                 _ = prop.valid_value(prop_val,
                                      prop_dict=self._prop_dict, error=True)
@@ -561,6 +562,8 @@ class Var:
         ('foo', ['ccpp_constant_one:dim1', 'ccpp_constant_one:dim2', 'bar'])
         >>> Var({'local_name' : 'foo(bar,:)', 'standard_name' : 'hi_mom', 'units' : 'm s-1', 'dimensions' : '(ccpp_constant_one:dim1)', 'type' : 'real',}, ParseSource('vname', 'HOST', ParseContext()), _MVAR_DUMMY_RUN_ENV).handle_array_ref()
         ('foo', ['bar', 'ccpp_constant_one:dim1'])
+        >>> Var({'local_name' : 'foo(:)', 'standard_name' : 'hi_mom', 'units' : 'm s-1', 'dimensions' : '(ccpp_constant_one:dim1)', 'type' : 'real',}, ParseSource('vname', 'HOST', ParseContext()), _MVAR_DUMMY_RUN_ENV).handle_array_ref()
+        ('foo', ['ccpp_constant_one:dim1'])
         >>> Var({'local_name' : 'foo(bar)', 'standard_name' : 'hi_mom', 'units' : 'm s-1', 'dimensions' : '(ccpp_constant_one:dim1)', 'type' : 'real',}, ParseSource('vname', 'HOST', ParseContext()), _MVAR_DUMMY_RUN_ENV).handle_array_ref() #doctest: +IGNORE_EXCEPTION_DETAIL
         Traceback (most recent call last):
         CCPPError: Call dims mismatch for foo(bar), not enough colons
@@ -610,8 +613,8 @@ class Var:
         # end if
         return lname, dimlist
 
-    def call_dimstring(self, var_dicts=None,
-                       explicit_dims=False, loop_subst=False):
+    def call_dimstring(self, var_dicts=None, explicit_dims=False,
+                       loop_subst=False, prepend_varname=False):
         """Return the dimensions string for a variable call.
         If <var_dict> is present, find and substitute a local_name for
         each standard_name in this variable's dimensions.
@@ -621,7 +624,7 @@ class Var:
            missing dimension.
         """
         emsg = ''
-        _, dims = self.handle_array_ref()
+        varname, dims = self.handle_array_ref()
         if var_dicts is not None:
             dimlist = []
             sepstr = ''
@@ -644,6 +647,13 @@ class Var:
                 if (not dvar) and add_dims:
                     dnames = []
                     for stdname in dstdnames:
+                        # Leave integers (parameters) alone
+                        try:
+                            if isinstance(int(stdname), int):
+                                dnames.append(stdname)
+                                continue
+                        except ValueError:
+                            pass
                         for vdict in var_dicts:
                             dvar = vdict.find_variable(standard_name=stdname,
                                                        any_scope=False)
@@ -690,7 +700,10 @@ class Var:
             lname = self.get_prop_value('local_name')
             raise CCPPError(emsg.format(vlnam=lname, ctx=ctx))
         # end if
-        return dimstr
+        if prepend_varname:
+            return varname + dimstr
+        else:
+            return dimstr
 
     def call_string(self, var_dicts, loop_vars=None):
         """Construct the actual argument string for this Var by translating
@@ -700,8 +713,8 @@ class Var:
         even if usage requires a loop substitution.
         """
         # DH*
-        if loop_vars:
-            raise Exception(f"DH DEBUG: WE DO USE loop_vars in call_string! '{loop_vars}'")
+        #if loop_vars:
+        #    raise Exception(f"DH DEBUG: WE DO USE loop_vars in call_string! '{loop_vars}'")
         # *DH
         if not isinstance(var_dicts, list):
            var_dicts = [var_dicts]

--- a/scripts/suite_objects.py
+++ b/scripts/suite_objects.py
@@ -53,60 +53,6 @@ _API_DUMMY_RUN_ENV = CCPPFrameworkEnv(_API_LOGGING,
                                              'scheme_files':'',
                                              'suites':''})
 
-# DH* MOVE THIS ELSEWHERE
-def split_dims_from_name(expr: str):
-    """Split the full dimension specifier of the innermost variable
-    of a potentially nested derived data type from the variable name:
-    
-    foo%bar(idx1)%baz(idx2, idx3(idx4), idx5a(idx6):idx5b(idx6))
-    -->
-    foo%bar(idx1)%baz AND (idx2, idx3(idx4), idx5a(idx6):idx5b(idx6))
-    
-    Walk the string from right to left, and find the outermost ( that
-    starts the final argument list at depth 0."""
-    name = expr
-    depth = 0
-    dimstring = None
-    for i in range(len(expr)-1, -1, -1):
-        c = expr[i]
-        if c == ')':
-            depth += 1
-        elif c == '(':
-            depth -= 1
-            if depth == 0:
-                # Found the outermost opening parenthesis
-                name = expr[:i]
-                dimstring = expr[i:]
-                break
-    if not dimstring:
-        return name, None
-
-    # Now turn the dimstring into a list of dimensions,
-    # taking into account that a dimension might have
-    # parentheses: (idx2, idx3(idx4), idx5a(idx6):idx5b(idx6))
-    dimstring = dimstring.lstrip('(').rstrip(')')
-    dims = []
-    current = []
-    depth = 0
-    for c in dimstring:
-        if c == '(':
-            depth += 1
-            current.append(c)
-        elif c == ')':
-            depth -= 1
-            current.append(c)
-        elif c == ',' and depth == 0:
-            dims.append(''.join(current).strip())
-            current = []
-        else:
-            current.append(c)
-    # Add last piece
-    if current:
-        dims.append(''.join(current).strip())
-
-    return name, dims
-# *DH
-
 ###############################################################################
 def new_suite_object(item, context, parent, run_env, loop_count=0):
 ###############################################################################
@@ -229,104 +175,8 @@ class CallList(VarDictionary):
                         lname = dummy+'_ptr'
                     # Finally, handle the dimensions unless it's an allocatable var
                     elif not var.get_prop_value('allocatable'):
-                        # DH* Consolidate this with the logic below for optional arguments ...
                         if dimensions:
-                            ddims = []
-                            for i in range(len(dimensions)):
-                                if is_horizontal_dimension(dimensions[i]):
-                                    if self.routine.run_phase():
-                                        # DH* Using this produces out of range exceptions. Begs a
-                                        # larger question of we should - internally - *always* use 
-                                        # horizontal_loop_begin:horizontal_loop_end, regardless
-                                        # of how it is defined in the metadata (e.g. convert
-                                        #   ccpp_constant_one:horizontal_loop_extent
-                                        # to
-                                        #   horizontal_loop_begin:horizontal_loop_end
-                                        # for the run phase when parsing the metadata ?
-                                        #if var_in_call_list and \
-                                        #   self.find_variable(standard_name="horizontal_loop_extent"):
-                                        #    ldim = "ccpp_constant_one"
-                                        #    udim = "horizontal_loop_extent"
-                                        #else:
-                                        #    ldim = "horizontal_loop_begin"
-                                        #    udim = "horizontal_loop_end"
-                                        # endif
-                                        ldim = "horizontal_loop_begin"
-                                        udim = "horizontal_loop_end"
-                                        # *DH
-                                    else:
-                                        ldim = "ccpp_constant_one"
-                                        udim = "horizontal_dimension"
-                                    # endif
-                                    # Get dimension for lower bound
-                                    for cldict in cldicts:
-                                        #lvar = cldict.find_variable(standard_name=ldim, any_scope=True)
-                                        lvar = cldict.find_variable(standard_name=ldim, any_scope=False)
-                                        if lvar:
-                                            break
-                                    if not lvar:
-                                        raise Exception(f"No variable with standard name '{ldim}' in cldict")
-                                    # end if
-                                    ldim_lname = lvar.call_string('local_name')
-                                    # Get dimension for upper bound
-                                    for cldict in cldicts:
-                                        #uvar = cldict.find_variable(standard_name=udim, any_scope=True)
-                                        uvar = cldict.find_variable(standard_name=udim, any_scope=False)
-                                        if uvar:
-                                            break
-                                    if not uvar:
-                                        raise Exception(f"No variable with standard name '{udim}' in cldict")
-                                    # end if
-                                    udim_lname = uvar.call_string('local_name')
-                                    ddims.append(ldim_lname + ':' + udim_lname)
-                                else:
-                                    # DH* TODO - explicit lbound and ubound as for optional args below
-                                    ddims.append(':')
-                                    # *DH
-                                # endif
-                            # end for
-
-                            lname, ldims = split_dims_from_name(dvar.call_string(search_dict))
-                            # This is where it gets tricky. We have a dimension specifier
-                            # as part of the local name, and we have a dimstr. The latter
-                            # contains the correct horizontal and vertical extents, the former
-                            # does not - they can be ranges (containing ":") or indices
-                            # (that is, the variable is a slice of another variable).
-                            # We need to walk the ldims list left to right and for each
-                            # dimension we need to check if it is a range or not. If it is
-                            # a range, we insert the first element from ddims, then we remove
-                            # this range from ddims and move on to the next.
-                            if ldims:
-                                # Consistency check:
-                                if len(ldims) < len(ddims):
-                                    raise Exception("Logic error in associate_optional_var: len({ldims}) < len({ddims})")
-                                for i in range(len(ldims)):
-                                    if ':' in ldims[i]:
-                                        ldims[i] = ddims.pop(0)
-                                # At the end ddims must be empty
-                                if ddims:
-                                    raise Exception("Logic error in associate_optional_var: after filling ldims='{ldims}' from ddims, ddims is not empty: '{ddims}'")
-                                dimstr = '(' + ','.join(ldims) + ')'
-                            else:
-                                dimstr = '(' + ','.join(ddims) + ')'
-                            if True: #ldims:
-                                print(f"DH DEBUG: dvar.call_string(search_dict) is '{dvar.call_string(search_dict)}'")
-                                print(f"DH DEBUG: lname, ldims: '{lname}' / '{ldims}'")
-                                print(f"DH DEBUG: dimstr: '{dimstr}'")
-                                tlname, tldims = dvar.handle_array_ref()
-                                print(f"DH DEBUG: tlname, tldims: '{tlname}' / '{tldims}'")
-                                print(f"DH DEBUG: dvar.call_dimstring(): '{dvar.call_dimstring()}'")
-                                print(f"DH DEBUG: dvar.call_dimstring(explicit_dims=True): '{dvar.call_dimstring(explicit_dims=True)}'")
-                                #print(f"DH DEBUG: dvar.call_dimstring(var_dicts=[self], explicit_dims=True): '{dvar.call_dimstring(var_dicts=[self], explicit_dims=True)}'")
-                                print(f"DH DEBUG: dvar.call_dimstring(var_dicts=cldicts, explicit_dims=True): '{dvar.call_dimstring(var_dicts=cldicts, explicit_dims=True)}'")
-                                print(f"DH DEBUG: dvar.call_dimstring(var_dicts=cldicts, explicit_dims=True, loop_subst=True): '{dvar.call_dimstring(var_dicts=cldicts, explicit_dims=True, loop_subst=True)}'")
-                                print(" ")
-                                #raise Exception("XXX")
-                            # DH*
-                            lname, ldims = split_dims_from_name(dvar.call_string(search_dict))
-                            dimstr = dvar.call_dimstring(var_dicts=cldicts, explicit_dims=True, loop_subst=self.routine.run_phase())
-                            # *DH
-                            lname += dimstr
+                            lname= dvar.call_dimstring(var_dicts=cldicts, explicit_dims=True, loop_subst=self.routine.run_phase(), prepend_varname=True)
                         # end if
                     # end if
                 else:
@@ -349,22 +199,6 @@ class CallList(VarDictionary):
                         # end if
                     # end for
                 # end if
-                #if is_func_call:
-                #    if cldicts is not None:
-                #        use_dicts = cldicts
-                #    else:
-                #        use_dicts = [self]
-                #    # end if
-                #    run_phase = self.routine.run_phase()
-                #    # We only need dimensions for suite variables in run phase
-                #    need_dims = SuiteObject.is_suite_variable(dvar) and run_phase
-                #    vdims = var.call_dimstring(var_dicts=use_dicts,
-                #                               explicit_dims=need_dims,
-                #                               loop_subst=run_phase)
-                #    if _BLANK_DIMS_RE.match(vdims) is None:
-                #        lname = lname + vdims
-                #    # end if
-                ## end if
                 if is_func_call:
                     arg_str += "{}{}={}".format(arg_sep, dummy, lname)
                 else:
@@ -1448,90 +1282,12 @@ class Scheme(SuiteObject):
         dimensions = dvar.get_dimensions()
         # Need to use local_name in Group's call list (self.__group.call_list),
         # not the local_name in var.
-        # DH* a lot of repeated logic here ... consolidate!
         if (dict_var):
             (conditional, _) = dvar.conditional(cldicts)
             if (has_transform):
                 lname = var.get_prop_value('local_name')+'_local'
             else:
-                #ddims = dvar.get_dimensions()
-                #for i in range(len(ddims)):
-                #    dim = ddims[i]
-                #    if is_horizontal_dimension(dim):
-                #        if self.run_phase():
-                #            if var_in_call_list and \
-                #               self.find_variable(standard_name="horizontal_loop_extent"):
-                #                ldim = "ccpp_constant_one"
-                #                udim = "horizontal_loop_extent"
-                #            else:
-                #                ldim = "horizontal_loop_begin"
-                #                udim = "horizontal_loop_end"
-                #            # endif
-                #        else:
-                #            ldim = "ccpp_constant_one"
-                #            udim = "horizontal_dimension"
-                #        # endif
-                #    else:
-                #        ldim, udim = dim.split(':')
-                #    # end if
-                #    # Get dimension for lower bound
-                #    for var_dict in cldicts:
-                #        lvar = var_dict.find_variable(standard_name=ldim, any_scope=False)
-                #        if lvar is not None:
-                #            break
-                #        # end if
-                #    # end for
-                #    if not lvar:
-                #        raise Exception(f"No variable with standard name '{ldim}' in cldicts")
-                #    # end if
-                #    ldim_lname = lvar.get_prop_value('local_name')
-                #    # Get dimension for upper bound
-                #    for var_dict in cldicts:
-                #        uvar = var_dict.find_variable(standard_name=udim, any_scope=False)
-                #        if uvar is not None:
-                #            break
-                #        # end if
-                #    # end for
-                #    if not uvar:
-                #        raise Exception(f"No variable with standard name '{udim}' in cldicts")
-                #    # end if
-                #    udim_lname = uvar.get_prop_value('local_name')
-                #    ddims[i] = ldim_lname + ':' + udim_lname
-                ## end for
-                #lname, ldims = split_dims_from_name(dvar.call_string(search_dict))
-                ## This is where it gets tricky. We have a dimension specifier
-                ## as part of the local name, and we have a dimstr. The latter
-                ## contains the correct horizontal and vertical extents, the former
-                ## does not - they can be ranges (containing ":") or indices
-                ## (that is, the variable is a slice of another variable).
-                ## We need to walk the ldims list left to right and for each
-                ## dimension we need to check if it is a range or not. If it is
-                ## a range, we insert the first element from ddims, then we remove
-                ## this range from ddims and move on to the next.
-                #if ldims:
-                #    # Consistency check:
-                #    if len(ldims) < len(ddims):
-                #        raise Exception("Logic error in associate_optional_var: len({ldims}) < len({ddims})")
-                #    for i in range(len(ldims)):
-                #        if ':' in ldims[i]:
-                #            ldims[i] = ddims.pop(0)
-                #    # At the end ddims must be empty
-                #    if ddims:
-                #        raise Exception("Logic error in associate_optional_var: after filling ldims='{ldims}' from ddims, ddims is not empty: '{ddims}'")
-                #    dimstr = '(' + ','.join(ldims) + ')'
-                #else:
-                #    dimstr = '(' + ','.join(ddims) + ')'
-                lname = dvar.get_prop_value("local_name")
-                print(f"lname 1: {lname}")
-                lname, ldims = split_dims_from_name(dvar.call_string(search_dict))
-                dimstr = dvar.call_dimstring(var_dicts=cldicts, explicit_dims=True, loop_subst=self.run_phase())
-                lname += dimstr
-                print(f"lname 2: {lname}")
-                lnametest = dvar.call_dimstring(var_dicts=cldicts, explicit_dims=True, loop_subst=self.run_phase(), prepend_varname=True)
-                print(f"lname 3: {lnametest}")
-                lnametest = dvar.call_string(search_dict, loop_vars=search_dict)
-                print(f"lname 4: {lnametest}")
-                #raise Exception("XXX")
+                lname = dvar.call_dimstring(var_dicts=cldicts, explicit_dims=True, loop_subst=self.run_phase(), prepend_varname=True)
                 
             # end if
             lname_ptr = var.get_prop_value('local_name') + '_ptr'
@@ -1545,7 +1301,6 @@ class Scheme(SuiteObject):
                 outfile.write(f"{lname_ptr} => {lname}", indent)
             # end if
         # end if
-        # *DH
     # end def
 
     def nullify_optional_var(self, dict_var, var, has_transform, cldicts, indent, outfile):

--- a/scripts/suite_objects.py
+++ b/scripts/suite_objects.py
@@ -309,8 +309,24 @@ class CallList(VarDictionary):
                                 dimstr = '(' + ','.join(ldims) + ')'
                             else:
                                 dimstr = '(' + ','.join(ddims) + ')'
+                            if True: #ldims:
+                                print(f"DH DEBUG: dvar.call_string(search_dict) is '{dvar.call_string(search_dict)}'")
+                                print(f"DH DEBUG: lname, ldims: '{lname}' / '{ldims}'")
+                                print(f"DH DEBUG: dimstr: '{dimstr}'")
+                                tlname, tldims = dvar.handle_array_ref()
+                                print(f"DH DEBUG: tlname, tldims: '{tlname}' / '{tldims}'")
+                                print(f"DH DEBUG: dvar.call_dimstring(): '{dvar.call_dimstring()}'")
+                                print(f"DH DEBUG: dvar.call_dimstring(explicit_dims=True): '{dvar.call_dimstring(explicit_dims=True)}'")
+                                #print(f"DH DEBUG: dvar.call_dimstring(var_dicts=[self], explicit_dims=True): '{dvar.call_dimstring(var_dicts=[self], explicit_dims=True)}'")
+                                print(f"DH DEBUG: dvar.call_dimstring(var_dicts=cldicts, explicit_dims=True): '{dvar.call_dimstring(var_dicts=cldicts, explicit_dims=True)}'")
+                                print(f"DH DEBUG: dvar.call_dimstring(var_dicts=cldicts, explicit_dims=True, loop_subst=True): '{dvar.call_dimstring(var_dicts=cldicts, explicit_dims=True, loop_subst=True)}'")
+                                print(" ")
+                                #raise Exception("XXX")
+                            # DH*
+                            lname, ldims = split_dims_from_name(dvar.call_string(search_dict))
+                            dimstr = dvar.call_dimstring(var_dicts=cldicts, explicit_dims=True, loop_subst=self.routine.run_phase())
+                            # *DH
                             lname += dimstr
-
                         # end if
                     # end if
                 else:
@@ -1438,74 +1454,85 @@ class Scheme(SuiteObject):
             if (has_transform):
                 lname = var.get_prop_value('local_name')+'_local'
             else:
-                ddims = dvar.get_dimensions()
-                for i in range(len(ddims)):
-                    dim = ddims[i]
-                    if is_horizontal_dimension(dim):
-                        if self.run_phase():
-                            if var_in_call_list and \
-                               self.find_variable(standard_name="horizontal_loop_extent"):
-                                ldim = "ccpp_constant_one"
-                                udim = "horizontal_loop_extent"
-                            else:
-                                ldim = "horizontal_loop_begin"
-                                udim = "horizontal_loop_end"
-                            # endif
-                        else:
-                            ldim = "ccpp_constant_one"
-                            udim = "horizontal_dimension"
-                        # endif
-                    else:
-                        ldim, udim = dim.split(':')
-                    # end if
-                    # Get dimension for lower bound
-                    for var_dict in cldicts:
-                        lvar = var_dict.find_variable(standard_name=ldim, any_scope=False)
-                        if lvar is not None:
-                            break
-                        # end if
-                    # end for
-                    if not lvar:
-                        raise Exception(f"No variable with standard name '{ldim}' in cldicts")
-                    # end if
-                    ldim_lname = lvar.get_prop_value('local_name')
-                    # Get dimension for upper bound
-                    for var_dict in cldicts:
-                        uvar = var_dict.find_variable(standard_name=udim, any_scope=False)
-                        if uvar is not None:
-                            break
-                        # end if
-                    # end for
-                    if not uvar:
-                        raise Exception(f"No variable with standard name '{udim}' in cldicts")
-                    # end if
-                    udim_lname = uvar.get_prop_value('local_name')
-                    ddims[i] = ldim_lname + ':' + udim_lname
-                # end for
+                #ddims = dvar.get_dimensions()
+                #for i in range(len(ddims)):
+                #    dim = ddims[i]
+                #    if is_horizontal_dimension(dim):
+                #        if self.run_phase():
+                #            if var_in_call_list and \
+                #               self.find_variable(standard_name="horizontal_loop_extent"):
+                #                ldim = "ccpp_constant_one"
+                #                udim = "horizontal_loop_extent"
+                #            else:
+                #                ldim = "horizontal_loop_begin"
+                #                udim = "horizontal_loop_end"
+                #            # endif
+                #        else:
+                #            ldim = "ccpp_constant_one"
+                #            udim = "horizontal_dimension"
+                #        # endif
+                #    else:
+                #        ldim, udim = dim.split(':')
+                #    # end if
+                #    # Get dimension for lower bound
+                #    for var_dict in cldicts:
+                #        lvar = var_dict.find_variable(standard_name=ldim, any_scope=False)
+                #        if lvar is not None:
+                #            break
+                #        # end if
+                #    # end for
+                #    if not lvar:
+                #        raise Exception(f"No variable with standard name '{ldim}' in cldicts")
+                #    # end if
+                #    ldim_lname = lvar.get_prop_value('local_name')
+                #    # Get dimension for upper bound
+                #    for var_dict in cldicts:
+                #        uvar = var_dict.find_variable(standard_name=udim, any_scope=False)
+                #        if uvar is not None:
+                #            break
+                #        # end if
+                #    # end for
+                #    if not uvar:
+                #        raise Exception(f"No variable with standard name '{udim}' in cldicts")
+                #    # end if
+                #    udim_lname = uvar.get_prop_value('local_name')
+                #    ddims[i] = ldim_lname + ':' + udim_lname
+                ## end for
+                #lname, ldims = split_dims_from_name(dvar.call_string(search_dict))
+                ## This is where it gets tricky. We have a dimension specifier
+                ## as part of the local name, and we have a dimstr. The latter
+                ## contains the correct horizontal and vertical extents, the former
+                ## does not - they can be ranges (containing ":") or indices
+                ## (that is, the variable is a slice of another variable).
+                ## We need to walk the ldims list left to right and for each
+                ## dimension we need to check if it is a range or not. If it is
+                ## a range, we insert the first element from ddims, then we remove
+                ## this range from ddims and move on to the next.
+                #if ldims:
+                #    # Consistency check:
+                #    if len(ldims) < len(ddims):
+                #        raise Exception("Logic error in associate_optional_var: len({ldims}) < len({ddims})")
+                #    for i in range(len(ldims)):
+                #        if ':' in ldims[i]:
+                #            ldims[i] = ddims.pop(0)
+                #    # At the end ddims must be empty
+                #    if ddims:
+                #        raise Exception("Logic error in associate_optional_var: after filling ldims='{ldims}' from ddims, ddims is not empty: '{ddims}'")
+                #    dimstr = '(' + ','.join(ldims) + ')'
+                #else:
+                #    dimstr = '(' + ','.join(ddims) + ')'
+                lname = dvar.get_prop_value("local_name")
+                print(f"lname 1: {lname}")
                 lname, ldims = split_dims_from_name(dvar.call_string(search_dict))
-                # This is where it gets tricky. We have a dimension specifier
-                # as part of the local name, and we have a dimstr. The latter
-                # contains the correct horizontal and vertical extents, the former
-                # does not - they can be ranges (containing ":") or indices
-                # (that is, the variable is a slice of another variable).
-                # We need to walk the ldims list left to right and for each
-                # dimension we need to check if it is a range or not. If it is
-                # a range, we insert the first element from ddims, then we remove
-                # this range from ddims and move on to the next.
-                if ldims:
-                    # Consistency check:
-                    if len(ldims) < len(ddims):
-                        raise Exception("Logic error in associate_optional_var: len({ldims}) < len({ddims})")
-                    for i in range(len(ldims)):
-                        if ':' in ldims[i]:
-                            ldims[i] = ddims.pop(0)
-                    # At the end ddims must be empty
-                    if ddims:
-                        raise Exception("Logic error in associate_optional_var: after filling ldims='{ldims}' from ddims, ddims is not empty: '{ddims}'")
-                    dimstr = '(' + ','.join(ldims) + ')'
-                else:
-                    dimstr = '(' + ','.join(ddims) + ')'
+                dimstr = dvar.call_dimstring(var_dicts=cldicts, explicit_dims=True, loop_subst=self.run_phase())
                 lname += dimstr
+                print(f"lname 2: {lname}")
+                lnametest = dvar.call_dimstring(var_dicts=cldicts, explicit_dims=True, loop_subst=self.run_phase(), prepend_varname=True)
+                print(f"lname 3: {lnametest}")
+                lnametest = dvar.call_string(search_dict, loop_vars=search_dict)
+                print(f"lname 4: {lnametest}")
+                #raise Exception("XXX")
+                
             # end if
             lname_ptr = var.get_prop_value('local_name') + '_ptr'
             # Scheme has optional varaible, host has varaible defined as Conditional (Active).

--- a/test/ddthost_test/environ_conditions.meta
+++ b/test/ddthost_test/environ_conditions.meta
@@ -1,6 +1,7 @@
 [ccpp-table-properties]
   name = environ_conditions
   type = scheme
+
 [ccpp-arg-table]
   name = environ_conditions_run
   type = scheme
@@ -27,6 +28,7 @@
   dimensions = ()
   type = integer
   intent = out
+
 [ccpp-arg-table]
   name = environ_conditions_init
   type = scheme
@@ -78,6 +80,7 @@
   dimensions = ()
   type = integer
   intent = out
+
 [ccpp-arg-table]
   name = environ_conditions_finalize
   type = scheme

--- a/test/ddthost_test/make_ddt.F90
+++ b/test/ddthost_test/make_ddt.F90
@@ -68,12 +68,10 @@ contains
   !> \section arg_table_make_ddt_init  Argument Table
   !! \htmlinclude arg_table_make_ddt_init.html
   !!
-  subroutine make_ddt_init(nbox, ccpp_info, vmr, errmsg, errflg)
-    use host_ccpp_ddt, only: ccpp_info_t
+  subroutine make_ddt_init(nbox, vmr, errmsg, errflg)
 
     ! Dummy arguments
     integer, intent(in) :: nbox
-    type(ccpp_info_t), intent(in) :: ccpp_info
     type(vmr_type), intent(out) :: vmr
     character(len=512), intent(out) :: errmsg
     integer, intent(out) :: errflg

--- a/test/ddthost_test/make_ddt.meta
+++ b/test/ddthost_test/make_ddt.meta
@@ -76,11 +76,6 @@
   units = count
   dimensions = ()
   intent = in
-[ ccpp_info ]
-  standard_name = host_standard_ccpp_type
-  type = ccpp_info_t
-  dimensions = ()
-  intent = in
 [ vmr ]
   standard_name = volume_mixing_ratio_ddt
   dimensions = ()


### PR DESCRIPTION
`scripts/metavar.py`: add option to prepend varname to `call_dimstring`
    - Todo: Can we replace the existing logic in `call_string` to do this? Or is that used differently in too many places?
    - Better name?

`scripts/ddt_library.py`: add `call_dimstring` to `VarDDT` class

`scripts/suite_objects.py`: use VarDDT/Var `call_dimstring` with `prepend_varname=True` and remove lots of unnecessary logic

Clean up test `test/ddthost_test` (remove unused variable)